### PR TITLE
update readme.md to include blank AppCenterId

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Create a file named `Secrets.cs` in the `XpoMusic/` directory, and put the follo
             internal static readonly string SpotifyClientId = "";
             internal static readonly string SpotifyClientSecret = "";
             internal static readonly string GoogleAnalyticsTrackerId = "";
+            internal static readonly string AppCenterId = "";
         }
     }
 


### PR DESCRIPTION
Your App.xmal.cs file is looking for AppCenterId on build as introduced with your app center integration commit https://github.com/MahdiGhiasi/XpoMusic/commit/d0a098f0b36170acdbeed9111eee4f9033f704e3

`if (!string.IsNullOrWhiteSpace(Secrets.AppCenterId))
            {
                AppCenter.LogLevel = LogLevel.Debug;
                AppCenter.Start(Secrets.AppCenterId, typeof(Analytics), typeof(Crashes));
            }`

 This addition allows for a successful build on a third party device without having to register on app center.